### PR TITLE
Update Molecule tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ arch:
 
 install:
   # Install test dependencies.
-  - pip install molecule docker molecule-docker
+  - pip install molecule docker molecule-docker ansible ansible-lint
 
 script:
   # Run tests.

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ arch:
 
 install:
   # Install test dependencies.
-  - pip install molecule docker
+  - pip install molecule docker molecule-docker
 
 script:
   # Run tests.

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ arch:
 
 install:
   # Install test dependencies.
-  - pip install molecule docker molecule-docker ansible ansible-lint
+  - pip install molecule docker molecule-docker ansible ansible-lint flake8
 
 script:
   # Run tests.

--- a/README.md
+++ b/README.md
@@ -16,20 +16,20 @@ xcuitrunner if you want to run tests on iOS devices.
 Role Variables
 --------------
 
-| Variable                 | Default   | Description
-|--------------------------|-----------|-------------------------------------------
-| `appium_version`         | `1.15.1`  | The version of Appium to install
-| `quamotion_version`      | `0.132.8` | The version of the Quamotion utilities (ios-deploy, xcuitrunner) to install
-| `xcshim_version`         | `0.1.4`   | The version of [xcshim](https://github.com/quamotion/xcshim) to install
-| `license_file_path`      |           | If available, the path to your Quamotion license file
-| `developer_profile_path` |           | If available, the path to your iOS Developer Profile
-| `devimg_dir`             |           | If available, the path to the directory which contains your Developer Disk images
-| `appium_user`            | `appium`  | The name of the service account for the Appium service
+| Variable                 | Default    | Description
+|--------------------------|------------|-------------------------------------------
+| `appium_version`         | `1.15.1`   | The version of Appium to install
+| `quamotion_version`      | `0.150.70` | The version of the Quamotion utility (xcuitrunner) to install
+| `xcshim_version`         | `0.1.4`    | The version of [xcshim](https://github.com/quamotion/xcshim) to install
+| `license_file_path`      |            | If available, the path to your Quamotion license file
+| `developer_profile_path` |            | If available, the path to your iOS Developer Profile
+| `devimg_dir`             |            | If available, the path to the directory which contains your Developer Disk images
+| `appium_user`            | `appium`   | The name of the service account for the Appium service
 
 Dependencies
 ------------
 
-- This role uses the [geerlingguy.nodejs] role to deploy node.js
+- This role uses the [geerlingguy.nodejs](https://github.com/geerlingguy/ansible-role-nodejs) role to deploy node.js
 
 Example Playbook
 ----------------

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ Role Variables
 |--------------------------|------------|-------------------------------------------
 | `appium_version`         | `1.15.1`   | The version of Appium to install
 | `quamotion_version`      | `0.150.70` | The version of the Quamotion utility (xcuitrunner) to install
-| `xcshim_version`         | `0.1.4`    | The version of [xcshim](https://github.com/quamotion/xcshim) to install
 | `license_file_path`      |            | If available, the path to your Quamotion license file
 | `developer_profile_path` |            | If available, the path to your iOS Developer Profile
 | `devimg_dir`             |            | If available, the path to the directory which contains your Developer Disk images

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 appium_version: "1.15.1"
-quamotion_version: "0.133.2"
+quamotion_version: "0.133.50"
 xcshim_version: "0.1.4"
 
 license_file_path: ""

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 appium_version: "1.15.1"
-quamotion_version: "0.133.50"
+quamotion_version: "0.150.70"
 xcshim_version: "0.1.4"
 
 license_file_path: ""

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Appium with iOS support
   company: Quamotion
   license: MIT
-  role_name: appium-ios
+  role_name: appium_ios
   min_ansible_version: 1.2
   galaxy_tags: []
   platforms:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -11,6 +11,6 @@ galaxy_info:
     - name: Ubuntu
       versions:
         - bionic
-        - eoan
+        - focal
 dependencies:
 - role: geerlingguy.nodejs

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -11,6 +11,5 @@ galaxy_info:
     - name: Ubuntu
       versions:
         - bionic
-        - focal
 dependencies:
 - role: geerlingguy.nodejs

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -11,5 +11,6 @@ galaxy_info:
     - name: Ubuntu
       versions:
         - bionic
+        - focal
 dependencies:
 - role: geerlingguy.nodejs

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -3,8 +3,11 @@ dependency:
   name: galaxy
 driver:
   name: docker
-lint:
-  name: yamllint
+lint: |
+  set -e
+  yamllint .
+  ansible-lint
+  flake8
 platforms:
   - name: ubuntu.18.04
     image: ubuntu:18.04
@@ -12,9 +15,5 @@ platforms:
     image: ubuntu:20.04
 provisioner:
   name: ansible
-  lint:
-    name: ansible-lint
 verifier:
   name: testinfra
-  lint:
-    name: flake8

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -8,8 +8,8 @@ lint:
 platforms:
   - name: ubuntu.18.04
     image: ubuntu:18.04
-  - name: ubuntu.19.10
-    image: ubuntu:19.10
+  - name: ubuntu.20.04
+    image: ubuntu:20.04
 provisioner:
   name: ansible
   lint:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -11,8 +11,6 @@ lint: |
 platforms:
   - name: ubuntu.18.04
     image: ubuntu:18.04
-  - name: ubuntu.20.04
-    image: ubuntu:20.04
 provisioner:
   name: ansible
 verifier:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -11,6 +11,8 @@ lint: |
 platforms:
   - name: ubuntu.18.04
     image: ubuntu:18.04
+  - name: ubuntu.20.04
+    image: ubuntu:20.04
 provisioner:
   name: ansible
 verifier:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -135,16 +135,19 @@
   copy:
     src: "{{ license_file_path }}"
     dest: /etc/quamotion/.license
+    mode: 0664
   when: (license_file_path is defined) and (license_file_path | length > 0)
 
 - name: Copy developer profile
   copy:
     src: "{{ developer_profile_path }}"
     dest: /etc/quamotion/quamotion.developerprofile
+    mode: 0664
   when: (developer_profile_path is defined) and (developer_profile_path | length > 0)
 
 - name: Copy developer disks
   copy:
     src: "{{ devimg_dir }}"
     dest: /etc/quamotion/devimg/
+    mode: 0664
   when: (devimg_dir is defined) and (devimg_dir | length > 0)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -111,22 +111,6 @@
   apt:
     deb: "https://qmcdn.blob.core.windows.net/download/xcuitrunner.{{ quamotion_version }}.linux-{{ quamotion_architecture }}.deb"
 
-- name: Install ios-deploy
-  apt:
-    deb: "https://qmcdn.blob.core.windows.net/download/ios-deploy.{{ quamotion_version }}.linux-{{ quamotion_architecture }}.deb"
-
-- name: Link ios-deploy into /usr/bin
-  file:
-    path: /usr/bin/ios-deploy
-    state: link
-    src: /usr/share/ios-deploy/ios-deploy
-
-- name: "Configure ios-deploy"
-  template:
-    src: "ios-deploy.appsettings"
-    dest: "/usr/share/ios-deploy/appsettings.json"
-    mode: 0664
-
 - name: Install xcshim
   apt:
     deb: "https://qmcdn.blob.core.windows.net/download/xcshim-{{ xcshim_version }}.deb"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -111,10 +111,6 @@
   apt:
     deb: "https://qmcdn.blob.core.windows.net/download/xcuitrunner.{{ quamotion_version }}.linux-{{ quamotion_architecture }}.deb"
 
-- name: Install xcshim
-  apt:
-    deb: "https://qmcdn.blob.core.windows.net/download/xcshim-{{ xcshim_version }}.deb"
-
 - name: Copy license file
   copy:
     src: "{{ license_file_path }}"


### PR DESCRIPTION
This PR updates the Ansible scripts and CI scripts so that CI becomes green again:

- Install molecule-docker, ansible, flake8, which is are no longer direct dependencies of molecule
- Migrate from Ubuntu 19.04 to Ubuntu 20.04
- Bump to version 0.150.70 for proper arm64 support
- Remove xcshim, ios-deploy dependencies

This represents the minimal effort required to make CI green; the rest is part of #4.