### PR TITLE
Appium WebDriverAgent folder permissions

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,26 +28,26 @@
 - name: "Register appium-webdriveragent folder"
   stat:
     path: /usr/lib/node_modules/appium/node_modules/appium-webdriveragent
-  register: appium-webdriveragent1
+  register: appiumwebdriveragent
 
 - name: "Update appium-webdriveragent folder permissions"
   file:
     path: /usr/lib/node_modules/appium/node_modules/appium-webdriveragent
     state: directory
     mode: "a+rwx"
-  when: appium-webdriveragent.exists
+  when: appiumwebdriveragent.stat.exists
 
 - name: "Register appium-xcuitest-driver appium-webdriveragent folder"
   stat:
     path: /usr/lib/node_modules/appium/node_modules/appium-xcuitest-driver/node_modules/appium-webdriveragent
-  register: appium-webdriveragent1-xcuirunner
+  register: appiumwebdriveragentxcuirunner
 
 - name: "Update appium-webdriveragent folder permissions"
   file:
     path: /usr/lib/node_modules/appium/node_modules/appium-xcuitest-driver/node_modules/appium-webdriveragent
     state: directory
     mode: "a+rwx"
-  when: appium-webdriveragent-xcuirunner.exists
+  when: appiumwebdriveragentxcuirunner.stat.exists
 
 - name: Create the Carthage directory, grant Appium user permissions
   file:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,11 +25,29 @@
     dest: "/etc/systemd/system/appium.service"
     mode: 0664
 
+- name: "Register appium-webdriveragent folder"
+    stat:
+      path: /usr/lib/node_modules/appium/node_modules/appium-webdriveragent
+    register: appium-webdriveragent1
+
 - name: "Update appium-webdriveragent folder permissions"
   file:
     path: /usr/lib/node_modules/appium/node_modules/appium-webdriveragent
     state: directory
     mode: "a+rwx"
+  when: appium-webdriveragent.exists
+
+- name: "Register appium-xcuitest-driver appium-webdriveragent folder"
+    stat:
+      path: /usr/lib/node_modules/appium/node_modules/appium-xcuitest-driver/node_modules/appium-webdriveragent
+    register: appium-webdriveragent1-xcuirunner
+
+- name: "Update appium-webdriveragent folder permissions"
+  file:
+    path: /usr/lib/node_modules/appium/node_modules/appium-xcuitest-driver/node_modules/appium-webdriveragent
+    state: directory
+    mode: "a+rwx"
+  when: appium-webdriveragent-xcuirunner.exists
 
 - name: Create the Carthage directory, grant Appium user permissions
   file:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,9 +26,9 @@
     mode: 0664
 
 - name: "Register appium-webdriveragent folder"
-    stat:
-      path: /usr/lib/node_modules/appium/node_modules/appium-webdriveragent
-    register: appium-webdriveragent1
+  stat:
+    path: /usr/lib/node_modules/appium/node_modules/appium-webdriveragent
+  register: appium-webdriveragent1
 
 - name: "Update appium-webdriveragent folder permissions"
   file:
@@ -38,9 +38,9 @@
   when: appium-webdriveragent.exists
 
 - name: "Register appium-xcuitest-driver appium-webdriveragent folder"
-    stat:
-      path: /usr/lib/node_modules/appium/node_modules/appium-xcuitest-driver/node_modules/appium-webdriveragent
-    register: appium-webdriveragent1-xcuirunner
+  stat:
+    path: /usr/lib/node_modules/appium/node_modules/appium-xcuitest-driver/node_modules/appium-webdriveragent
+  register: appium-webdriveragent1-xcuirunner
 
 - name: "Update appium-webdriveragent folder permissions"
   file:


### PR DESCRIPTION
Update the folder permissions of the webdriver-agent folder to make sure the XCUITRunner can write the signed WebDriverAgent.