### PR TITLE
Add xcuitrunner check

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -31,3 +31,4 @@ rules:
     type: unix
   trailing-spaces: disable
   truthy: disable
+  

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -183,6 +183,10 @@
     mode: 0664
   when: (devimg_dir is defined) and (devimg_dir | length > 0)
 
+- name: Check Quamotion XCUITRunner
+  command: xcuitrunner run --exit
+  tags: ['molecule-notest', 'skip_ansible_lint']
+
 - name: Start appium service
   systemd:
     name: appium

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -183,8 +183,10 @@
     mode: 0664
   when: (devimg_dir is defined) and (devimg_dir | length > 0)
 
-- name: Check Quamotion XCUITRunner
-  command: xcuitrunner run --exit
+- name:  Check Quamotion XCUITRunner
+  shell: |
+    usbmuxd
+    xcuitrunner run --exit
   tags: ['molecule-notest', 'skip_ansible_lint']
 
 - name: Start appium service

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -195,5 +195,4 @@
   shell: |
     usbmuxd
     xcuitrunner run --exit
-  tags: [ never, debug, molecule-notest, skip_ansible_lint]
-  
+  tags: [ never, debug, 'molecule-notest', 'skip_ansible_lint']

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -196,3 +196,4 @@
     usbmuxd
     xcuitrunner run --exit
   tags: [ never, debug]
+  

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -195,5 +195,5 @@
   shell: |
     usbmuxd
     xcuitrunner run --exit
-  tags: [ never, debug]
+  tags: [ never, debug, molecule-notest, skip_ansible_lint]
   

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -183,12 +183,6 @@
     mode: 0664
   when: (devimg_dir is defined) and (devimg_dir | length > 0)
 
-- name:  Check Quamotion XCUITRunner
-  shell: |
-    usbmuxd
-    xcuitrunner run --exit
-  tags: ['molecule-notest', 'skip_ansible_lint']
-
 - name: Start appium service
   systemd:
     name: appium

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -195,4 +195,4 @@
   shell: |
     usbmuxd
     xcuitrunner run --exit
-  tags: ['debug', 'molecule-notest', 'skip_ansible_lint']
+  tags: [ never, debug]

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -141,6 +141,17 @@
     mode: 0775
     owner: "{{ appium_user }}"
 
+- name: Register machine id
+  command: xcuitrunner --machineId
+  register: machine_id_output
+  tags: ['molecule-notest', 'skip_ansible_lint']
+
+- name: Request trial license
+  fail:
+    msg: "No license is provided. You can request a trial license at http://docs.quamotion.mobi/license?machineId={{ machine_id_output.stdout }}"
+  when: (license_file_path is not defined) or (license_file_path | length <= 0)
+  tags: ['molecule-notest', 'skip_ansible_lint']
+
 - name: "Copy developerprofile passwordfile"
   template:
     src: "quamotion.developerprofile.password"
@@ -171,6 +182,10 @@
     owner: "{{ appium_user }}"
     mode: 0664
   when: (devimg_dir is defined) and (devimg_dir | length > 0)
+
+- name: Check Quamotion XCUITRunner
+  command: xcuitrunner run --exit
+  tags: ['molecule-notest', 'skip_ansible_lint']
 
 - name: Start appium service
   systemd:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -183,12 +183,6 @@
     mode: 0664
   when: (devimg_dir is defined) and (devimg_dir | length > 0)
 
-- name:  Check Quamotion XCUITRunner
-  shell: |
-    usbmuxd
-    xcuitrunner run --exit
-  tags: ['molecule-notest', 'skip_ansible_lint']
-
 - name: Start appium service
   systemd:
     name: appium
@@ -196,3 +190,9 @@
     enabled: yes
     daemon_reload: yes
   tags: ['molecule-notest']
+
+- name:  Check Quamotion XCUITRunner
+  shell: |
+    usbmuxd
+    xcuitrunner run --exit
+  tags: ['debug', 'molecule-notest', 'skip_ansible_lint']


### PR DESCRIPTION
The PR adds some checks to improve the setup experience:
 - execute "xcuitrunner run --exit" to have a basic verification of the remote configuration.
 - echo machineId and trial license url so users can request a trial license.